### PR TITLE
Fix /rloot showing only Blood Furnace by hardening EJ loading and enumerating instances

### DIFF
--- a/BloodFurnaceLoot/BloodFurnaceLoot.toc
+++ b/BloodFurnaceLoot/BloodFurnaceLoot.toc
@@ -4,5 +4,6 @@
 ## Author: dloweinc + Codex
 ## Version: 0.1.0
 ## SavedVariables: LootBrowserDB
+## OptionalDeps: Blizzard_EncounterJournal
 
 BloodFurnaceLoot.lua


### PR DESCRIPTION
### Motivation
- The addon previously only showed The Blood Furnace because Encounter Journal (EJ) APIs were not reliably available at login and the code matched instance names against an English-only list, causing misses in other locales or when EJ wasn't loaded yet. 
- The change aims to ensure EJ is available when building dynamic loot tables and to enumerate all client-returned instances so all dungeons/raids appear in the UI.

### Description
- Added `EnsureEncounterJournalLoaded()` which attempts to load `Blizzard_EncounterJournal` if EJ APIs are not present, and declared `## OptionalDeps: Blizzard_EncounterJournal` in the `.toc` so the dependency is explicit. 
- Replaced name-based lookup with `CollectJournalInstances()` that enumerates and returns a sorted list of EJ instances for dungeons and raids, and updated `BuildTBCAnniversaryLootData()` to build Normal/Heroic/Raid entries from that list. 
- Improved `BuildDungeonFromJournal()` to obtain a human-readable zone via `C_Map.GetMapInfo` when possible, and preserved Rare+ filtering via `LootBrowser.MIN_QUALITY`. 
- UI fixes: added a scrollable left-side instance list (`dungeonScroll` / `dungeonScrollChild`), used it when creating buttons, set the scroll child height, and appended a difficulty suffix to the content header; added a chat fallback message when EJ data cannot be loaded.

### Testing
- Verified diffs and file contents with `sed`/`nl`/`rg` to confirm `EnsureEncounterJournalLoaded`, `CollectJournalInstances`, `BuildTBCAnniversaryLootData`, and TOC `OptionalDeps` are present and the UI scroll child is wired into `BuildDungeonButtons`, and these inspections succeeded. 
- Applied automated patching scripts (Python) to update the Lua and TOC files and confirmed the updated source contains the expected replacements, and the scripts ran successfully. 
- Confirmed repository status and shown diffs/logs to validate the textual changes, and these checks succeeded. 
- Runtime validation inside World of Warcraft is not possible in this environment, so in-game behavior (EJ availability, zone name resolution, and actual loot rendering) was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699234bf55c0832294fe68470db832be)